### PR TITLE
visualize page now lists visualizable files in /dropbox folder, provides working link to visualization page

### DIFF
--- a/apps/pvacviz/src/app/core/actions/dropbox.actions.ts
+++ b/apps/pvacviz/src/app/core/actions/dropbox.actions.ts
@@ -1,0 +1,40 @@
+import { Action } from '@ngrx/store';
+import { File } from '../models/file.model';
+
+export enum DropboxActionTypes {
+  Load = '[Dropboxes] Load Dropbox Files',
+  LoadSuccess = '[Dropboxes] Load Dropbox Files Success',
+  LoadFail = '[Dropboxes] Load Dropbox Files Fail',
+}
+
+/**
+ * Every action is comprised of at least a type and an optional
+ * payload. Expressing actions as classes enables powerful
+ * type checking in reducer functions.
+ *
+ * See Discriminated Unions: https://www.typescriptlang.org/docs/handbook/advanced-types.html#discriminated-unions
+ */
+export class Load implements Action {
+  readonly type = DropboxActionTypes.Load;
+
+  constructor() { }
+}
+
+export class LoadSuccess implements Action {
+  readonly type = DropboxActionTypes.LoadSuccess;
+
+  constructor(public payload: File[]) { }
+}
+
+export class LoadFail implements Action {
+  readonly type = DropboxActionTypes.LoadFail;
+
+  constructor(public payload: any) { }
+}
+
+/**
+ * Export a type alias of all actions in this action group
+ * so that reducers can easily compose action types
+ */
+export type DropboxActions =
+  Load | LoadSuccess | LoadFail;

--- a/apps/pvacviz/src/app/core/core.module.ts
+++ b/apps/pvacviz/src/app/core/core.module.ts
@@ -12,8 +12,11 @@ import { NotFoundComponent } from './containers/not-found/not-found.component';
 
 import { ProcessService } from './services/process.service';
 import { InputService } from './services/inputs.service';
+import { DropboxService } from './services/dropbox.service';
 
 import { ProcessEffects } from './effects/process.effects';
+import { DropboxEffects } from './effects/dropbox.effects';
+
 import { reducers } from './reducers';
 
 export const COMPONENTS = [
@@ -27,11 +30,12 @@ export const COMPONENTS = [
     RouterModule,
     ClarityModule,
     StoreModule.forFeature('core', reducers),
-    EffectsModule.forFeature([ProcessEffects])
+    EffectsModule.forFeature([ProcessEffects, DropboxEffects])
   ],
   providers: [
     ProcessService,
-    InputService
+    InputService,
+    DropboxService
   ],
   declarations: COMPONENTS,
   exports: COMPONENTS

--- a/apps/pvacviz/src/app/core/effects/dropbox.effects.ts
+++ b/apps/pvacviz/src/app/core/effects/dropbox.effects.ts
@@ -1,0 +1,62 @@
+import { Injectable, InjectionToken, Optional, Inject } from '@angular/core';
+
+import { Effect, Actions, ofType } from '@ngrx/effects';
+import { Action } from '@ngrx/store';
+
+import { Observable } from 'rxjs/Observable';
+import { Scheduler } from 'rxjs/Scheduler';
+import { async } from 'rxjs/scheduler/async';
+import { empty } from 'rxjs/observable/empty';
+import { of } from 'rxjs/observable/of';
+import {
+  debounceTime,
+  map,
+  switchMap,
+  skip,
+  takeUntil,
+  catchError,
+} from 'rxjs/operators';
+
+import { File, Files } from '../../core/models/file.model';
+import { DropboxService } from '../../core/services/dropbox.service';
+import { ProcessService } from '../../core/services/process.service';
+import {
+  DropboxActionTypes,
+  DropboxActions,
+  Load,
+  LoadSuccess,
+  LoadFail
+} from '../actions/dropbox.actions';
+import { ApiDropboxResponse } from '../../core/models/api-responses.model';
+
+/**
+ * Effects offer a way to isolate and easily test side-effects within your
+ * application.
+ *
+ * If you are unfamiliar with the operators being used in these examples, please
+ * check out the sources below:
+ *
+ * Official Docs: http://reactivex.io/rxjs/manual/overview.html#categories-of-operators
+ * RxJS 5 Operators By Example: https://gist.github.com/btroncone/d6cf141d6f2c00dc6b35
+ */
+
+@Injectable()
+export class DropboxEffects {
+  constructor(
+    private actions$: Actions,
+    private dropbox: DropboxService,
+  ) { }
+
+  @Effect()
+  search$: Observable<Action> = this.actions$.pipe(
+    ofType<Load>(DropboxActionTypes.Load),
+    switchMap(action => {
+      return this.dropbox
+        .query()
+        .pipe(
+          map((files: Files) => new LoadSuccess(files)),
+          catchError(err => of(new LoadFail(err)))
+        );
+    })
+  );
+}

--- a/apps/pvacviz/src/app/core/models/api-responses.model.ts
+++ b/apps/pvacviz/src/app/core/models/api-responses.model.ts
@@ -7,3 +7,4 @@ export interface ApiStartResponse {
 }
 
 export interface ApiInputResponse extends Array<File> { }
+export interface ApiDropboxResponse extends Array<File> { }

--- a/apps/pvacviz/src/app/core/reducers/dropbox.reducer.ts
+++ b/apps/pvacviz/src/app/core/reducers/dropbox.reducer.ts
@@ -1,0 +1,81 @@
+import { createSelector } from '@ngrx/store';
+import { createEntityAdapter, EntityAdapter, EntityState } from '@ngrx/entity';
+import { File, Files } from '../../core/models/file.model';
+import { DropboxActions, DropboxActionTypes } from '../actions/dropbox.actions';
+
+/**
+ * @ngrx/entity provides a predefined interface for handling
+ * a structured dictionary of records. This interface
+ * includes an array of ids, and a dictionary of the provided
+ * model type by id. This interface is then extended to include
+ * any additional interface properties.
+ */
+export interface State extends EntityState<File> {
+  loading: boolean;
+  loaded: boolean;
+  error: boolean;
+  errorMessage?: string;
+}
+
+/**
+ * createEntityAdapter creates many an object of helper
+ * functions for single or multiple operations
+ * against the dictionary of records. The configuration
+ * object takes a record id selector function and
+ * a sortComparer option which is set to a compare
+ * function if the records are to be sorted.
+ */
+export const adapter: EntityAdapter<File> = createEntityAdapter<File>({
+  selectId: (file: File) => file.fileID,
+  sortComparer: false,
+});
+
+/**
+ * getInitialState returns the default initial state
+ * for the generated entity state. Initial state
+ * additional properties can also be defined.
+ */
+export const initialState: State = adapter.getInitialState({
+  loading: false,
+  loaded: false,
+  error: false,
+  errorMessage: null
+});
+
+export function reducer(state = initialState, action: DropboxActions): State {
+  switch (action.type) {
+
+    case DropboxActionTypes.Load:
+      return {
+        ...state,
+        loading: true,
+      };
+
+    case DropboxActionTypes.LoadSuccess:
+      return {
+        /**
+         * The addMany function provided by the created adapter
+         * adds many records to the entity dictionary
+         * and returns a new state including those records. If
+         * the collection is to be sorted, the adapter will
+         * sort each record upon entry into the sorted array.
+         */
+        ...adapter.addMany(action.payload, state),
+        loading: false,
+        loaded: true,
+        error: false
+      };
+
+    case DropboxActionTypes.LoadFail:
+      return {
+        ...state,
+        loading: false,
+        loaded: false,
+        error: false,
+        errorMessage: action.payload.message
+      }
+
+    default:
+      return state;
+  }
+}

--- a/apps/pvacviz/src/app/core/reducers/index.ts
+++ b/apps/pvacviz/src/app/core/reducers/index.ts
@@ -2,12 +2,14 @@ import { createSelector, createFeatureSelector } from '@ngrx/store';
 import * as fromRoot from '../../reducers';
 import * as fromLayout from './layout.reducer';
 import * as fromProcesses from './processes.reducer';
+import * as fromDropbox from './dropbox.reducer';
 
 import { map, filter } from 'lodash-es';
 
 export interface CoreState {
   layout: fromLayout.State;
   processes: fromProcesses.State;
+  dropbox: fromDropbox.State;
 }
 
 export interface State extends fromRoot.State {
@@ -16,7 +18,8 @@ export interface State extends fromRoot.State {
 
 export const reducers = {
   layout: fromLayout.reducer,
-  processes: fromProcesses.reducer
+  processes: fromProcesses.reducer,
+  dropbox: fromDropbox.reducer
 }
 
 /**
@@ -61,6 +64,11 @@ export const getProcessesState = createSelector(
   core => core.processes
 );
 
+export const getDropboxState = createSelector(
+  getCoreState,
+  core => core.dropbox
+);
+
 /**
  * Adapters created with @ngrx/entity generate
  * commonly used selector functions including
@@ -73,6 +81,11 @@ export const {
   selectEntities: getProcesses,
   selectAll: getAllProcesses,
 } = fromProcesses.adapter.getSelectors(getProcessesState);
+
+export const {
+  selectEntities: getDropboxFiles,
+  selectAll: getAllDropboxFiles,
+} = fromDropbox.adapter.getSelectors(getDropboxState);
 
 export const getRouteProcessId = createSelector(
   fromRoot.getRouterState,
@@ -91,7 +104,7 @@ export const getProcessesWithVisualizableFiles = createSelector(
     return map(processes)
       .filter((proc) => {
         const vizFiles = filter(proc.files, (file) => {
-          return (file.display_name.includes('final\.tsv') || file.display_name.includes('combined\.parsed\.tsv'));
+          return isVisualizable(file.display_name);
         });
         return vizFiles.length > 0;
         // console.log('proc!');
@@ -100,3 +113,15 @@ export const getProcessesWithVisualizableFiles = createSelector(
         // }) > 0;
       });
   })
+
+export const getDropboxVisualizableFiles = createSelector(
+  getDropboxFiles,
+  (files) => {
+    return map(files)
+      .filter(file => isVisualizable(file.display_name));
+  }
+)
+
+function isVisualizable(display_name) {
+  return (display_name.includes('final\.tsv') || display_name.includes('combined\.parsed\.tsv'));
+}

--- a/apps/pvacviz/src/app/core/services/dropbox.service.ts
+++ b/apps/pvacviz/src/app/core/services/dropbox.service.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs/Rx';
+import 'rxjs/add/operator/map';
+
+import { map, filter, first } from 'lodash-es';
+
+import { ApiDropboxResponse } from '../../core/models/api-responses.model';
+import { File } from '../../core/models/file.model';
+
+@Injectable()
+export class DropboxService {
+  private API_PATH = 'http://localhost:4200/api/v1';
+
+  constructor(private http: HttpClient) { }
+
+  query(): Observable<ApiDropboxResponse> {
+    return this.http.get(`${this.API_PATH}/dropbox`)
+      .map(parseResponse);
+
+  }
+}
+
+function parseResponse(res: Response): ApiDropboxResponse {
+  return map(res, (f) => {
+    f.display_name = f.display_name
+      .split('/')
+      .slice(-1)
+      .join('/');
+    return f as File;
+  })
+    .filter(f => first(f.display_name) !== '.'); // filter out invisible files
+}

--- a/apps/pvacviz/src/app/manage/containers/manage-page/manage-page.component.ts
+++ b/apps/pvacviz/src/app/manage/containers/manage-page/manage-page.component.ts
@@ -29,7 +29,7 @@ export class ManagePageComponent implements OnInit {
             .split('/')
             .slice(-2)
             .join('/');
-        })
+        });
       }
     ))
   }

--- a/apps/pvacviz/src/app/visualize/containers/visualize-page/visualize-page.component.html
+++ b/apps/pvacviz/src/app/visualize/containers/visualize-page/visualize-page.component.html
@@ -1,17 +1,29 @@
 <div class="page-header">
   <div class="row">
-    <div class="col-xs-8">
+    <div class="col-xs-6">
       <h3 class="page-title">
         <span class="page-type">Visualize Process Results</span>
       </h3>
     </div>
-    <div class="col-xs-4 text-right page-buttons">
+    <div class="col-xs-6">
+      <h3 class="page-title">
+        <span class="page-type">Visualize Dropbox Files</span>
+      </h3>
     </div>
   </div>
 </div>
-<div class="page-content" >
-  <div class="row" >
-    <div class="col-xs-12" >
+<div class="page-content">
+  <div class="row">
+    <div class="col-xs-6">
+      <ng-container [ngSwitch]="(processesWithVisualizableFiles$ | async)?.length > 0">
+        <p *ngSwitchCase="true" >
+          Listed below are processes with visualizable files.<br/>
+        </p>
+        <p *ngSwitchDefault>
+          No processes found with visualizable files.
+        </p>
+      </ng-container>
+      <p></p>
       <div class="card" *ngFor="let process of (processesWithVisualizableFiles$ | async)">
         <div class="card-header">
           <div class="row">
@@ -26,27 +38,25 @@
             <table class="table table-compact table-noborder file-table">
               <thead>
                 <tr>
-                  <th class="left">&nbsp;</th>
+                  <th class="left">Filename</th>
                   <th class="left">Description</th>
                   <th></th>
                 </tr>
               </thead>
               <tbody>
                 <ng-container [ngSwitch]="process.files.length > 0">
-                  <ng-container *ngSwitchCase="true" >
+                  <ng-container *ngSwitchCase="true">
                     <ng-container *ngFor="let file of process.files">
                       <tr *ngIf="(file.display_name.includes('final\.tsv') || file.display_name.includes('combined\.parsed\.tsv' ))">
                         <td class="left">{{file.display_name.split('/').slice(-1)}}</td>
                         <td class="left">{{file.description}}</td>
                         <td class="right">
-                          <button [routerLink]="['/visualize/process', process.id, 'results', file.fileID]"
-                            [disabled]="!(file.display_name.includes('final\.tsv') || file.display_name.includes('combined\.parsed\.tsv' ))"
-                            class="btn btn-sm btn-link">Visualize</button>
+                          <button [routerLink]="['/visualize/process', process.id, 'results', file.fileID]" class="btn btn-sm btn-link">Visualize</button>
                         </td>
                       </tr>
                     </ng-container>
                   </ng-container>
-                  <ng-container *ngSwitchCase="false" >
+                  <ng-container *ngSwitchCase="false">
                     <tr>
                       <td colspan="3">
                         Process produced no files.
@@ -61,6 +71,43 @@
 
       </div>
     </div>
+    <div class="col-xs-6">
+      <ng-container [ngSwitch]="(dropboxFiles$ | async)?.length > 0">
+        <p *ngSwitchCase="true" >
+          Listed below are all visualizable files found in ~/pVACseq/Dropbox/.
+          Files?: {{(dropboxFiles$ | async)?.length > 0}}
+          Length: {{(dropboxFiles$ | async)?.length }}
+        </p>
+        <p *ngSwitchDefault>
+          No visualizable files found in ~/pVACseq/Dropbox/.
+        </p>
+      </ng-container>
+      <div class="card" *ngIf="(dropboxFiles$ | async)?.length > 0">
+        <div class="card-block files">
+          <div class="card-text">
+            <table class="table table-compact table-noborder file-table">
+              <thead>
+                <tr>
+                  <th class="left">Filename</th>
+                  <th class="left">Description</th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody>
+                <ng-container *ngFor="let file of (dropboxFiles$ | async)">
+                  <tr>
+                    <td class="left">{{file.display_name}}</td>
+                    <td class="left">{{file.description}}</td>
+                    <td class="right">
+                      <button [routerLink]="['/visualize/process', '-1', 'results', file.fileID]" class="btn btn-sm btn-link">Visualize</button>
+                    </td>
+                  </tr>
+                </ng-container>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
-<!-- <pre>{{(processesWithVisualizableFiles$ | async) | json}}</pre> -->

--- a/apps/pvacviz/src/app/visualize/containers/visualize-page/visualize-page.component.scss
+++ b/apps/pvacviz/src/app/visualize/containers/visualize-page/visualize-page.component.scss
@@ -1,0 +1,27 @@
+.card-block.files {
+  .card-text {
+    margin-bottom: -.25rem;
+    margin-left: -.75rem;
+    margin-right: -.75rem;
+    margin-top: -.5rem;
+
+    .file-table {
+      margin-bottom: 0;
+      margin-top: 0;
+      th {
+        background-color: #EFEFEF;
+      }
+
+      tr {
+        td:first-child, th:first-child {
+          padding-left: .75rem;
+        }
+
+        td:last-child, th:last-child {
+          padding-right: .75rem;
+        }
+
+      }
+    }
+  }
+}

--- a/apps/pvacviz/src/app/visualize/containers/visualize-page/visualize-page.component.ts
+++ b/apps/pvacviz/src/app/visualize/containers/visualize-page/visualize-page.component.ts
@@ -2,8 +2,11 @@ import { Component, OnInit } from '@angular/core';
 import { Store, select } from '@ngrx/store';
 
 import { Observable } from 'rxjs/Observable';
+import { filter, map } from 'rxjs/operators';
 
+import { File } from '../../../core/models/file.model';
 import { Process } from '../../../core/models/process.model';
+import * as dropbox from '../../../core/actions/dropbox.actions';
 import * as processes from '../../../core/actions/process.actions';
 import * as fromCore from '../../../core/reducers';
 
@@ -14,15 +17,19 @@ import * as fromCore from '../../../core/reducers';
 })
 export class VisualizePageComponent implements OnInit {
   processes$: Observable<Process[]>;
-  processesWithVisualizableFiles$: Observable<Process[]>
+  processesWithVisualizableFiles$: Observable<Process[]>;
+  dropboxFiles$: Observable<File[]>;
 
   constructor(private store: Store<fromCore.State>) {
     this.processes$ = store.pipe(select(fromCore.getAllProcesses));
     this.processesWithVisualizableFiles$ = store.pipe(select(fromCore.getProcessesWithVisualizableFiles));
+    // this.dropboxFiles$ = store.pipe(select(fromCore.getAllDropboxFiles));
+    this.dropboxFiles$ = store.pipe(select(fromCore.getDropboxVisualizableFiles));
   }
 
   ngOnInit() {
     this.store.dispatch(new processes.Load());
+    this.store.dispatch(new dropbox.Load());
   }
 
   reload() {


### PR DESCRIPTION
In addition to process results files, the Visualization page now lists all visualizable files in the /dropbox folder. Clicking on 'Visualize' next to each will bring up the same visualization used on the process files.