### PR TITLE
use host IP address instead of localhost for API and bokeh requests

### DIFF
--- a/apps/pvacviz/src/app/core/core.module.ts
+++ b/apps/pvacviz/src/app/core/core.module.ts
@@ -16,10 +16,10 @@ import { AlgorithmsService } from '@pvz/core/services/algorithms.service';
 import { AllelesService } from '@pvz/core/services/alleles.service';
 import { InputService } from '@pvz/core/services/inputs.service';
 import { DropboxService } from '@pvz/core/services/dropbox.service';
+import { WINDOW_PROVIDERS } from '@pvz/core/services/window.provider';
 
 import { ProcessEffects } from '@pvz/core/effects/process.effects';
 import { DropboxEffects } from '@pvz/core/effects/dropbox.effects';
-
 import { reducers } from './reducers';
 
 export const COMPONENTS = [
@@ -41,7 +41,8 @@ export const COMPONENTS = [
     AlgorithmsService,
     AllelesService,
     InputService,
-    DropboxService
+    DropboxService,
+    WINDOW_PROVIDERS
   ],
   declarations: COMPONENTS,
   exports: COMPONENTS

--- a/apps/pvacviz/src/app/core/services/config.service.ts
+++ b/apps/pvacviz/src/app/core/services/config.service.ts
@@ -1,12 +1,15 @@
-import { Injectable } from '@angular/core';
+import { Injectable, Inject } from '@angular/core';
 import { environment } from '@pvz/environments/environment';
+import { WINDOW } from '@pvz/core/services/window.provider';
 
 @Injectable()
 export class ConfigService {
 
+  constructor(@Inject(WINDOW) private window: Window) { }
+
   server = {
     protocol: 'http://',
-    domain: 'localhost',
+    hostname: this.window.location.hostname,
     port: environment.production ? 8080 : 4200,
     api: 'api',
     version: 'v1'
@@ -14,7 +17,7 @@ export class ConfigService {
 
   bokehServer = {
     protocol: 'http://',
-    domain: 'localhost',
+    hostname: this.window.location.hostname,
     port: 8080,
     api: 'api',
     version: 'v1'
@@ -22,13 +25,13 @@ export class ConfigService {
 
   serverUrl() {
     return this.server.protocol +
-      this.server.domain + ':' +
+      this.server.hostname + ':' +
       this.server.port;
   }
 
   apiUrl() {
     return this.server.protocol +
-      this.server.domain + ':' +
+      this.server.hostname + ':' +
       this.server.port + '/' +
       this.server.api + '/' +
       this.server.version;
@@ -36,7 +39,7 @@ export class ConfigService {
 
   bokehUrl() {
     return this.bokehServer.protocol +
-      this.bokehServer.domain + ':' +
+      this.bokehServer.hostname + ':' +
       this.bokehServer.port + '/' +
       this.bokehServer.api + '/' +
       this.bokehServer.version;

--- a/apps/pvacviz/src/app/core/services/dropbox.service.ts
+++ b/apps/pvacviz/src/app/core/services/dropbox.service.ts
@@ -8,11 +8,10 @@ import { map, filter, first } from 'lodash-es';
 import { ApiDropboxResponse } from '@pvz/core/models/api-responses.model';
 import { File } from '@pvz/core/models/file.model';
 
-import { ConfigService } from './config.service';
+import { ConfigService } from '@pvz/core/services/config.service';
 
 @Injectable()
 export class DropboxService {
-  private API_PATH = 'http://localhost:4200/api/v1';
   private dropboxPath: string;
 
   constructor(private http: HttpClient, conf: ConfigService) {

--- a/apps/pvacviz/src/app/core/services/window.provider.ts
+++ b/apps/pvacviz/src/app/core/services/window.provider.ts
@@ -1,0 +1,12 @@
+import { InjectionToken, FactoryProvider } from '@angular/core';
+
+export const WINDOW = new InjectionToken<Window>('window');
+
+const windowProvider: FactoryProvider = {
+  provide: WINDOW,
+  useFactory: () => window
+};
+
+export const WINDOW_PROVIDERS = [
+  windowProvider
+]

--- a/apps/pvacviz/src/app/manage/containers/manage-page/manage-page.component.ts
+++ b/apps/pvacviz/src/app/manage/containers/manage-page/manage-page.component.ts
@@ -40,7 +40,8 @@ export class ManagePageComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.store.dispatch(new processes.Load({ count: 10, page: 1 }));
+    // the datagrid emits a refresh event on init, making the following call unnecessary
+    // this.store.dispatch(new processes.Load({ count: 10, page: 1 }));
   }
 
   // initially this component had an onInit function, clr-datagrid emits a refresh event

--- a/apps/pvacviz/src/app/visualize/containers/visualize-file/visualize-file.component.ts
+++ b/apps/pvacviz/src/app/visualize/containers/visualize-file/visualize-file.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { Store, select } from '@ngrx/store';
 
@@ -6,11 +6,12 @@ import { Observable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs';
 
 import 'rxjs/add/observable/of';
-import { take, combineLatest, switchMap, withLatestFrom, filter } from 'rxjs/operators';
+import { take, switchMap, withLatestFrom } from 'rxjs/operators';
+
+import { ConfigService } from '@pvz/core/services/config.service';
 
 import { File } from '@pvz/core/models/file.model';
 import { Process } from '@pvz/core/models/process.model';
-import { environment } from '@pvz/environments/environment';
 import * as fromCore from '@pvz/core/reducers';
 import * as processes from '@pvz/core/actions/process.actions';
 import * as dropbox from '@pvz/core/actions/dropbox.actions';
@@ -35,7 +36,9 @@ export class VisualizeFileComponent implements OnInit {
   subscriptions: Subscription[] = [];
 
   constructor(private store: Store<fromCore.State>,
+    private conf: ConfigService,
     private sanitizer: DomSanitizer) {
+
     this.processId$ = store.pipe(select(fromCore.getRouteProcessId));
     this.fileId$ = store.pipe(select(fromCore.getRouteFileId));
     this.visualizeUrl$ = this.processId$.pipe(
@@ -43,9 +46,9 @@ export class VisualizeFileComponent implements OnInit {
       switchMap(
         ([processId, fileId]) => {
           console.log('processId: ' + processId + '; fileId: ' + fileId);
-          const visualizeUrl = this.bokehUrl() + '/processes/' +
+          const visualizeUrl = this.conf.bokehUrl() + '/processes/' +
             processId + '/results/' + fileId + '/visualize';
-          return Observable.of(sanitizer.bypassSecurityTrustResourceUrl(visualizeUrl));
+          return Observable.of(this.sanitizer.bypassSecurityTrustResourceUrl(visualizeUrl));
         }
       )
     );
@@ -73,43 +76,4 @@ export class VisualizeFileComponent implements OnInit {
   ngOnDestroy() {
     this.subscriptions.map(sub => sub.unsubscribe());
   }
-
-  private server = {
-    protocol: 'http://',
-    domain: 'localhost',
-    port: environment.production ? 8080 : 4200,
-    api: 'api',
-    version: 'v1'
-  };
-
-  private bokehServer = {
-    protocol: 'http://',
-    domain: 'localhost',
-    port: 8080,
-    api: 'api',
-    version: 'v1'
-  };
-
-  private serverUrl() {
-    return this.server.protocol +
-      this.server.domain + ':' +
-      this.server.port;
-  }
-
-  private japiUrl() {
-    return this.server.protocol +
-      this.server.domain + ':' +
-      this.server.port + '/' +
-      this.server.api + '/' +
-      this.server.version;
-  }
-
-  private bokehUrl() {
-    return this.bokehServer.protocol +
-      this.bokehServer.domain + ':' +
-      this.bokehServer.port + '/' +
-      this.bokehServer.api + '/' +
-      this.bokehServer.version;
-  }
-
 }


### PR DESCRIPTION
This is a corresponding PR to the server-features PR on pVACtools. Instead of using localhost, the client now fetches the URL's hostname/ip and uses that for API access. This enables usage on a remote server instead of just one's local machine.